### PR TITLE
Refactor salary properties and update decimal configurations

### DIFF
--- a/BankingSystem.DAL/Data/Configurations/AdminConfiguration.cs
+++ b/BankingSystem.DAL/Data/Configurations/AdminConfiguration.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BankingSystem.DAL.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace BankingSystem.DAL.Data.Configurations
+{
+    public class AdminConfiguration : IEntityTypeConfiguration<Admin>
+    {
+        public void Configure(EntityTypeBuilder<Admin> builder)
+        {
+            builder.Property(a => a.Salary)
+                .IsRequired()
+                .HasColumnType("decimal(18,4)");
+        }
+    }
+}

--- a/BankingSystem.DAL/Data/Configurations/LoanConfiguration.cs
+++ b/BankingSystem.DAL/Data/Configurations/LoanConfiguration.cs
@@ -15,11 +15,11 @@ namespace BankingSystem.DAL.Data.Configurations
         {
             // Configure LoanAmount with decimal precision
             builder.Property(l => l.LoanAmount)
-                   .HasPrecision(18, 4)
+                .HasColumnType("decimal(18,4)")
                 .IsRequired();
 
             builder.Property(L => L.CurrentDebt)
-                   .HasPrecision(18, 4)
+                .HasColumnType("decimal(18,4)")
                 .IsRequired();
 
 

--- a/BankingSystem.DAL/Data/Configurations/ManagerConfiguration.cs
+++ b/BankingSystem.DAL/Data/Configurations/ManagerConfiguration.cs
@@ -11,6 +11,10 @@ namespace BankingSystem.DAL.Configurations
             builder.HasOne(m => m.Branch)
                .WithOne(b => b.MyManager)
                .HasForeignKey<MyManager>(m => m.BranchId);
+
+            builder.Property(m => m.Salary)
+            .IsRequired()
+             .HasColumnType("decimal(18,4)");
         }
     }
 }

--- a/BankingSystem.DAL/Data/Configurations/PaymentConfiguration.cs
+++ b/BankingSystem.DAL/Data/Configurations/PaymentConfiguration.cs
@@ -15,7 +15,7 @@ namespace BankingSystem.DAL.Configurations
             // Properties
             builder.Property(p => p.Amount)
                    .IsRequired()
-                   .HasPrecision(18,4);
+                .HasColumnType("decimal(18,4)");
 
             builder.Property(p => p.PaymentDate)
                    .IsRequired()

--- a/BankingSystem.DAL/Data/Configurations/SavingsConfiguration.cs
+++ b/BankingSystem.DAL/Data/Configurations/SavingsConfiguration.cs
@@ -15,7 +15,7 @@ namespace BankingSystem.DAL.Data.Configurations
 
             builder.Property(s => s.Balance)
                    .IsRequired()
-                   .HasPrecision(18, 4);
+                .HasColumnType("decimal(18,4)");
 
             builder.Property(S => S.IsDeleted)
                 .HasDefaultValue(false);

--- a/BankingSystem.DAL/Data/Configurations/TellerConfiguration.cs
+++ b/BankingSystem.DAL/Data/Configurations/TellerConfiguration.cs
@@ -8,9 +8,9 @@ namespace BankingSystem.DAL.Configurations
     {
         public void Configure(EntityTypeBuilder<Teller> builder)
         {
-            //builder.Property(t => t.Salary)
-            //    .IsRequired()
-            //    .HasColumnType("float");
+            builder.Property(t => t.Salary)
+                .IsRequired()
+                .HasColumnType("decimal(18,4)");
         }
     }
 }

--- a/BankingSystem.DAL/Migrations/Development/20250407002741_addSalaryandconverttodouble.Designer.cs
+++ b/BankingSystem.DAL/Migrations/Development/20250407002741_addSalaryandconverttodouble.Designer.cs
@@ -4,6 +4,7 @@ using BankingSystem.DAL.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BankingSystem.DAL.Migrations.Development
 {
     [DbContext(typeof(BankingSystemContext))]
-    partial class BankingSystemContextModelSnapshot : ModelSnapshot
+    [Migration("20250407002741_addSalaryandconverttodouble")]
+    partial class addSalaryandconverttodouble
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BankingSystem.DAL/Migrations/Development/20250407002741_addSalaryandconverttodouble.cs
+++ b/BankingSystem.DAL/Migrations/Development/20250407002741_addSalaryandconverttodouble.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BankingSystem.DAL.Migrations.Development
+{
+    /// <inheritdoc />
+    public partial class addSalaryandconverttodouble : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "Salary",
+                table: "Tellers",
+                type: "decimal(18,4)",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "Salary",
+                table: "Managers",
+                type: "decimal(18,4)",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "Salary",
+                table: "Admins",
+                type: "decimal(18,4)",
+                nullable: false,
+                defaultValue: 0m);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Salary",
+                table: "Tellers");
+
+            migrationBuilder.DropColumn(
+                name: "Salary",
+                table: "Managers");
+
+            migrationBuilder.DropColumn(
+                name: "Salary",
+                table: "Admins");
+        }
+    }
+}

--- a/BankingSystem.DAL/Models/Admin.cs
+++ b/BankingSystem.DAL/Models/Admin.cs
@@ -9,6 +9,7 @@ namespace BankingSystem.DAL.Models
 {
     public class Admin : ApplicationUser
     {
+        public double Salary { get; set; }
         [ForeignKey(nameof(Bank))]
         public int? BankId { get; set; }
         public Bank Bank { get; set; } = null!;

--- a/BankingSystem.DAL/Models/ApplicationUser.cs
+++ b/BankingSystem.DAL/Models/ApplicationUser.cs
@@ -14,7 +14,6 @@ namespace BankingSystem.DAL.Models
         public string FirstName { get; set; } = null!;
         public string LastName { get; set; } = null!;
         public string Address { get; set; } = null!;
-     
         public DateTime JoinDate { get; set; }
         public DateTime BirthDate { get; set; }
         public string Discriminator { get; set; } = null!;

--- a/BankingSystem.DAL/Models/Loan.cs
+++ b/BankingSystem.DAL/Models/Loan.cs
@@ -26,8 +26,8 @@ namespace BankingSystem.DAL.Models
 
     public class Loan : BaseEntity
     {
-        public decimal LoanAmount { get; set; }
-        public decimal CurrentDebt { get; set; }
+        public double LoanAmount { get; set; }
+        public double CurrentDebt { get; set; }
         public int InterestRate { get; set; }
         public int DurationInMonth { get; set; }
         public LoanStatus LoanStatus { get; set; }

--- a/BankingSystem.DAL/Models/MyManager.cs
+++ b/BankingSystem.DAL/Models/MyManager.cs
@@ -9,6 +9,8 @@ namespace BankingSystem.DAL.Models
 {
     public class MyManager : ApplicationUser
     {
+        public double Salary { get; set; }
+
         [ForeignKey(nameof(Branch))]
         public int? BranchId { get; set; }
         public Branch Branch { get; set; } = null!;

--- a/BankingSystem.DAL/Models/Payment.cs
+++ b/BankingSystem.DAL/Models/Payment.cs
@@ -9,7 +9,7 @@ namespace BankingSystem.DAL.Models
 {
     public class Payment : BaseEntity
     {
-        public decimal Amount { get; set; }
+        public double Amount { get; set; }
         public DateTime PaymentDate { get; set; }
 
         [ForeignKey(nameof(Loan))]

--- a/BankingSystem.DAL/Models/Savings.cs
+++ b/BankingSystem.DAL/Models/Savings.cs
@@ -10,7 +10,7 @@ namespace BankingSystem.DAL.Models
     public class Savings : BaseEntity
     {
         public string Currency { get; set; } = null!;
-        public decimal Balance { get; set; }
+        public double Balance { get; set; }
 
         [ForeignKey(nameof(Branch))]
         public int BranchId { get; set; }

--- a/BankingSystem.DAL/Models/Teller.cs
+++ b/BankingSystem.DAL/Models/Teller.cs
@@ -9,7 +9,9 @@ namespace BankingSystem.DAL.Models
 {
     public class Teller : ApplicationUser
     {
-        //public double Salary { get; set; }
+        public double Salary { get; set; }
+
+
         [ForeignKey(nameof(Branch))]
         public int? BranchId { get; set; }
         public Branch Branch { get; set; } = null!;


### PR DESCRIPTION
Refactor salary properties and update decimal configurations

- Updated Loan, Payment, Savings, and Teller configurations to use .HasColumnType("decimal(18,4)") instead of .HasPrecision(18, 4).
- Added Salary property to MyManager and Teller entities, and created AdminConfiguration for Admin entity.
- Changed LoanAmount and CurrentDebt types from decimal to double in Loan class.
- Added Salary property of type double to Admin, MyManager, Payment, and Savings classes.
- Created migration to add Salary columns to Tellers, Managers, and Admins tables.